### PR TITLE
Remove sleep from loadcart

### DIFF
--- a/main_cart.py
+++ b/main_cart.py
@@ -473,15 +473,11 @@ class CartWindow(QMainWindow):
             parsed = arduboy.fxcart.parse(bindata, repprog)
             repstatus("Rendering items...")
             count = 0
-            rest = 1
             for slot in parsed:
                 self._add_slot_signal.emit(slot, count == 0)
                 count += 1
                 repprog(count, len(parsed))
-                # This is a hack. The UI does not update unless this is here. An exponentially decreasing thread sleep
-                if count == rest:
-                    time.sleep(0.01)
-                    rest = rest << 1
+                
         self.list_widget.blockSignals(True)
         try:
             dialog = widget_progress.do_progress_work(do_work, "Loading cart", simple = True)

--- a/widget_progress.py
+++ b/widget_progress.py
@@ -45,6 +45,7 @@ class ProgressWindow(QDialog):
             layout.addWidget(self.ok_button, alignment=Qt.AlignmentFlag.AlignCenter)
 
         self.setLayout(layout)
+        self.show()
     
     def set_device(self, device):
         if self.simple:


### PR DESCRIPTION
## Issue
- `loadcart()`  used `time.sleep()` as a hack to update the UI

## Changes
- Call `show` in `ProgressWindow` during initialization
- Removed need for `time.sleep()`